### PR TITLE
Fix Unicode escape sequences in tool input output

### DIFF
--- a/src/extract_claude_logs.py
+++ b/src/extract_claude_logs.py
@@ -122,7 +122,7 @@ class ClaudeConversationExtractor:
                                 conversation.append(
                                     {
                                         "role": "tool_use",
-                                        "content": f"🔧 Tool: {tool_name}\nInput: {json.dumps(tool_input, indent=2)}",
+                                        "content": f"🔧 Tool: {tool_name}\nInput: {json.dumps(tool_input, indent=2, ensure_ascii=False)}",
                                         "timestamp": entry.get("timestamp", ""),
                                     }
                                 )
@@ -183,7 +183,7 @@ class ClaudeConversationExtractor:
                         tool_name = item.get("name", "unknown")
                         tool_input = item.get("input", {})
                         text_parts.append(f"\n🔧 Using tool: {tool_name}")
-                        text_parts.append(f"Input: {json.dumps(tool_input, indent=2)}\n")
+                        text_parts.append(f"Input: {json.dumps(tool_input, indent=2, ensure_ascii=False)}\n")
             return "\n".join(text_parts)
         else:
             return str(content)


### PR DESCRIPTION
## Summary
Fixes Unicode characters (Korean, Chinese, Japanese, etc.) being displayed as escape sequences like `\uc0ac\uc6a9\uc790` instead of actual readable text in HTML, JSON, and Markdown exports when using the `--detailed` flag.

## Problem
When exporting conversations with `--detailed` flag, tool inputs containing non-ASCII characters were being escaped:

**Before:**
```json
{
  "thought": "\uc0ac\uc6a9\uc790\uac00 \ucf58\ud150\uce20 \uc81c\ubaa9\uc744 \ud568\uaed8 \uc54c\ub824\ub2ec\ub77c\uace0 \uc694\uccad\ud588\uc2b5\ub2c8\ub2e4",
  "thoughtNumber": 1
}
```

**After:**
```json
{
  "thought": "사용자가 콘텐츠 제목을 함께 알려달라고 요청했습니다",
  "thoughtNumber": 1
}
```

This made exported conversations with non-ASCII tool inputs unreadable, especially problematic for international users.

## Solution
Added `ensure_ascii=False` parameter to `json.dumps()` calls when serializing tool inputs. Python's `json.dumps()` uses `ensure_ascii=True` by default, which escapes all non-ASCII characters.

## Changes
- **Line 125** (`extract_conversation` method): Added `ensure_ascii=False` to tool_use content formatting
- **Line 186** (`_extract_text_content` method): Added `ensure_ascii=False` to detailed mode tool_use formatting

## Testing
- ✅ Core unit tests pass (`test_extract_text_content_list`)
- ✅ Manual verification with Unicode characters confirms proper display
- ✅ No breaking changes to existing functionality

## Impact
- Improves readability for all non-ASCII characters in tool inputs
- Affects HTML, JSON, and Markdown exports when using `--detailed` flag
- No impact on basic extraction without `--detailed` flag
- Backward compatible - no API or CLI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)