### PR TITLE
fix timezone issues

### DIFF
--- a/src/extract_claude_logs.py
+++ b/src/extract_claude_logs.py
@@ -310,7 +310,7 @@ class ClaudeConversationExtractor:
             date_str = datetime.now().strftime("%Y-%m-%d")
             time_str = ""
 
-        filename = f"claude-conversation-{date_str}-{session_id[:8]}.md"
+        filename = f"claude-conversation-{date_str}-{time_str}-{session_id[:8]}.md"
         output_path = self.output_dir / filename
 
         with open(output_path, "w", encoding="utf-8") as f:
@@ -371,7 +371,7 @@ class ClaudeConversationExtractor:
             date_str = datetime.now().strftime("%Y-%m-%d")
             time_str = ""
 
-        filename = f"claude-conversation-{date_str}-{session_id[:8]}.json"
+        filename = f"claude-conversation-{date_str}-{time_str}-{session_id[:8]}.json"
         output_path = self.output_dir / filename
 
         # Create JSON structure
@@ -411,7 +411,7 @@ class ClaudeConversationExtractor:
             date_str = datetime.now().strftime("%Y-%m-%d")
             time_str = ""
 
-        filename = f"claude-conversation-{date_str}-{session_id[:8]}.html"
+        filename = f"claude-conversation-{date_str}-{time_str}-{session_id[:8]}.html"
         output_path = self.output_dir / filename
 
         # HTML template with modern styling

--- a/src/extract_claude_logs.py
+++ b/src/extract_claude_logs.py
@@ -363,10 +363,13 @@ class ClaudeConversationExtractor:
                 local_time_struct = time.localtime(dt.timestamp())
 
                 date_str = time.strftime("%Y-%m-%d", local_time_struct)
+                time_str = time.strftime("%H:%M:%S", local_time_struct)
             except Exception:
                 date_str = datetime.now().strftime("%Y-%m-%d")
+                time_str = ""
         else:
             date_str = datetime.now().strftime("%Y-%m-%d")
+            time_str = ""
 
         filename = f"claude-conversation-{date_str}-{session_id[:8]}.json"
         output_path = self.output_dir / filename
@@ -374,7 +377,7 @@ class ClaudeConversationExtractor:
         # Create JSON structure
         output = {
             "session_id": session_id,
-            "date": date_str,
+            "date": date_str + " " + time_str,
             "message_count": len(conversation),
             "messages": conversation
         }


### PR DESCRIPTION
- Fix 1: The current output time does not account for time zones.

- Fix 2: The timestamp format in JSON output is inconsistent with that used in Markdown/HTML.

- Feature1: Added timestamps to filenames. Although the current filename includes a session_id, from the user's perspective, it is easier to locate the desired log file by time.

- Suggestion 1: Blank lines should not contain any characters.