### PR TITLE
feat: Support custom claude project path

### DIFF
--- a/src/interactive_ui.py
+++ b/src/interactive_ui.py
@@ -183,6 +183,7 @@ class InteractiveUI:
 
         # Create and run real-time search
         rts = RealTimeSearch(smart_searcher, self.extractor)
+        rts.search_dir = self.extractor.claude_dir  # Use custom claude_dir if set
         selected_file = rts.run()
 
         if selected_file:


### PR DESCRIPTION
## Summary

Add --claude-dir CLI option to specify a custom Claude projects directory instead of the hardcoded ~/.claude/projects path.

## Changes

- Add CLAUDE_PROJECTS_DIR environment variable support in ClaudeConversationExtractor
- Add --claude-dir CLI option to argparse
- Set environment variable when --claude-dir option is provided in main() and launch_interactive()
- Pass search_dir to search functions to respect custom directory setting

## Motivation

Users may have Claude projects stored in non-default locations or want to analyze conversations from different Claude installations. This change allows specifying an alternative directory path.

## Usage

```
# Using CLI option
claude-extract --claude-dir /path/to/.claude/projects --list

# Using environment variable
CLAUDE_PROJECTS_DIR=/path/to/.claude/projects claude-extract --list
```
