### PR TITLE
Preserve non-ASCII characters in tool input when extracting conversations

### DIFF
--- a/src/extract_claude_logs.py
+++ b/src/extract_claude_logs.py
@@ -122,7 +122,7 @@ class ClaudeConversationExtractor:
                                 conversation.append(
                                     {
                                         "role": "tool_use",
-                                        "content": f"🔧 Tool: {tool_name}\nInput: {json.dumps(tool_input, indent=2)}",
+                                        "content": f"🔧 Tool: {tool_name}\nInput: {json.dumps(tool_input, indent=2, ensure_ascii=False)}",
                                         "timestamp": entry.get("timestamp", ""),
                                     }
                                 )
@@ -183,7 +183,7 @@ class ClaudeConversationExtractor:
                         tool_name = item.get("name", "unknown")
                         tool_input = item.get("input", {})
                         text_parts.append(f"\n🔧 Using tool: {tool_name}")
-                        text_parts.append(f"Input: {json.dumps(tool_input, indent=2)}\n")
+                        text_parts.append(f"Input: {json.dumps(tool_input, indent=2, ensure_ascii=False)}\n")
             return "\n".join(text_parts)
         else:
             return str(content)


### PR DESCRIPTION
Adds `ensure_ascii=False` to both `json.dumps()` calls that serialize **tool use input** in `src/extract_claude_logs.py`, so that exported conversation logs show non-ASCII characters as readable text instead of Unicode escape sequences.