### PR TITLE
Add --thinking flag to include thinking blocks in output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ test-output/
 test_conversations/
 local_tests/
 test_*.py
+!tests/test_*.py
 
 # Database and cache files
 *.db

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 **Export Claude Code conversations with the #1 extraction tool.** Claude Code stores chats in ~/.claude/projects as JSONL files with no export button - this tool solves that.
 
+GitHub Copilot CLI sessions are also supported with `--copilot`, which reads from `~/.copilot/session-state/`.
+
 🔥 **What users search for:** [Export Claude conversations](#how-to-export-claude-code-conversations) | [Claude Code logs location](#where-are-claude-code-logs-stored) | [Backup Claude sessions](#backup-all-claude-conversations) | [Claude JSONL to Markdown](#convert-claude-jsonl-to-markdown)
 
 ## 📸 How to Export Claude Code Conversations - Demo
@@ -149,6 +151,15 @@ claude-extract --all
 
 # Save Claude logs to custom location
 claude-extract --output ~/my-claude-backups
+
+# List Copilot CLI sessions instead of Claude Code sessions
+claude-extract --copilot --list
+
+# Export recent Copilot CLI sessions
+claude-extract --copilot --recent 5
+
+# Search Copilot CLI sessions
+claude-extract --copilot --search "tool.execution_complete"
 ```
 
 ### 📄 Export Formats - NEW in v1.1.1!
@@ -211,6 +222,10 @@ claude-extract
 - **Windows**: `%USERPROFILE%\.claude\projects\*\chat_*.jsonl`
 - **Format**: Undocumented JSONL with base64 encoded content
 
+### GitHub Copilot CLI Default Locations:
+- **macOS/Linux**: `~/.copilot/session-state/*/events.jsonl`
+- **Format**: Per-session JSONL event streams with user, assistant, and tool events
+
 ### Exported Claude Conversation Locations:
 ```text
 ~/Desktop/Claude logs/claude-conversation-2025-06-09-abc123.md
@@ -219,6 +234,8 @@ claude-extract
 ├── Claude responses with 🤖 prefix
 └── Clean Markdown formatting
 ```
+
+When `--copilot` is active, the default export destination changes to `~/Desktop/Copilot logs/` and exported files use the `copilot-conversation-*` prefix.
 
 ## ❓ Frequently Asked Questions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ claude-start = "extract_claude_logs:launch_interactive"
 claude-search = "search_cli:main"
 
 [tool.setuptools]
-py-modules = ["extract_claude_logs", "interactive_ui", "search_conversations", "realtime_search", "search_cli"]
+py-modules = ["extract_claude_logs", "interactive_ui", "search_conversations", "realtime_search", "search_cli", "source_config"]
 
 [tool.setuptools.package-dir]
 "" = "src"

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         "search_conversations",
         "realtime_search",
         "search_cli",
+        "source_config",
     ],
     entry_points={
         "console_scripts": [

--- a/src/extract_claude_logs.py
+++ b/src/extract_claude_logs.py
@@ -65,12 +65,13 @@ class ClaudeConversationExtractor:
                 sessions.append(jsonl_file)
         return sorted(sessions, key=lambda x: x.stat().st_mtime, reverse=True)
 
-    def extract_conversation(self, jsonl_path: Path, detailed: bool = False) -> List[Dict[str, str]]:
+    def extract_conversation(self, jsonl_path: Path, detailed: bool = False, thinking: bool = False) -> List[Dict[str, str]]:
         """Extract conversation messages from a JSONL file.
-        
+
         Args:
             jsonl_path: Path to the JSONL file
             detailed: If True, include tool use, MCP responses, and system messages
+            thinking: If True, include extended thinking blocks
         """
         conversation = []
 
@@ -101,7 +102,7 @@ class ClaudeConversationExtractor:
                             msg = entry["message"]
                             if isinstance(msg, dict) and msg.get("role") == "assistant":
                                 content = msg.get("content", [])
-                                text = self._extract_text_content(content, detailed=detailed)
+                                text = self._extract_text_content(content, detailed=detailed, thinking=thinking)
 
                                 if text and text.strip():
                                     conversation.append(
@@ -162,12 +163,13 @@ class ClaudeConversationExtractor:
 
         return conversation
 
-    def _extract_text_content(self, content, detailed: bool = False) -> str:
+    def _extract_text_content(self, content, detailed: bool = False, thinking: bool = False) -> str:
         """Extract text from various content formats Claude uses.
-        
+
         Args:
             content: The content to extract from
             detailed: If True, include tool use blocks and other metadata
+            thinking: If True, include extended thinking blocks
         """
         if isinstance(content, str):
             return content
@@ -178,6 +180,10 @@ class ClaudeConversationExtractor:
                 if isinstance(item, dict):
                     if item.get("type") == "text":
                         text_parts.append(item.get("text", ""))
+                    elif thinking and item.get("type") == "thinking":
+                        thinking_text = item.get("thinking", "")
+                        if thinking_text:
+                            text_parts.append(f"\n💭 Thinking:\n{thinking_text}\n")
                     elif detailed and item.get("type") == "tool_use":
                         # Include tool use details in detailed mode
                         tool_name = item.get("name", "unknown")
@@ -188,16 +194,17 @@ class ClaudeConversationExtractor:
         else:
             return str(content)
 
-    def display_conversation(self, jsonl_path: Path, detailed: bool = False) -> None:
+    def display_conversation(self, jsonl_path: Path, detailed: bool = False, thinking: bool = False) -> None:
         """Display a conversation in the terminal with pagination.
-        
+
         Args:
             jsonl_path: Path to the JSONL file
             detailed: If True, include tool use and system messages
+            thinking: If True, include extended thinking blocks
         """
         try:
             # Extract conversation
-            messages = self.extract_conversation(jsonl_path, detailed=detailed)
+            messages = self.extract_conversation(jsonl_path, detailed=detailed, thinking=thinking)
             
             if not messages:
                 print("❌ No messages found in conversation")
@@ -247,6 +254,8 @@ class ClaudeConversationExtractor:
                     print(f"\n📤 TOOL RESULT:")
                 elif role == "system":
                     print(f"\nℹ️ SYSTEM:")
+                elif role == "thinking":
+                    print(f"\n💭 THINKING:")
                 else:
                     print(f"\n{role.upper()}:")
                 
@@ -335,6 +344,9 @@ class ClaudeConversationExtractor:
                     f.write(f"{content}\n\n")
                 elif role == "system":
                     f.write("### ℹ️ System\n\n")
+                    f.write(f"{content}\n\n")
+                elif role == "thinking":
+                    f.write("### 💭 Thinking\n\n")
                     f.write(f"{content}\n\n")
                 else:
                     f.write(f"## {role}\n\n")
@@ -666,16 +678,17 @@ class ClaudeConversationExtractor:
         return sessions[:limit]
 
     def extract_multiple(
-        self, sessions: List[Path], indices: List[int], 
-        format: str = "markdown", detailed: bool = False
+        self, sessions: List[Path], indices: List[int],
+        format: str = "markdown", detailed: bool = False, thinking: bool = False
     ) -> Tuple[int, int]:
         """Extract multiple sessions by index.
-        
+
         Args:
             sessions: List of session paths
             indices: Indices to extract
             format: Output format ('markdown', 'json', 'html')
             detailed: If True, include tool use and system messages
+            thinking: If True, include extended thinking blocks
         """
         success = 0
         total = len(indices)
@@ -683,7 +696,7 @@ class ClaudeConversationExtractor:
         for idx in indices:
             if 0 <= idx < len(sessions):
                 session_path = sessions[idx]
-                conversation = self.extract_conversation(session_path, detailed=detailed)
+                conversation = self.extract_conversation(session_path, detailed=detailed, thinking=thinking)
                 if conversation:
                     output_path = self.save_conversation(conversation, session_path.stem, format=format)
                     success += 1
@@ -717,6 +730,7 @@ Examples:
   %(prog)s --format json --all       # Export all as JSON
   %(prog)s --format html --extract 1 # Export session 1 as HTML
   %(prog)s --detailed --extract 1    # Include tool use & system messages
+  %(prog)s --thinking --extract 1    # Include extended thinking blocks
         """,
     )
     parser.add_argument("--list", action="store_true", help="List recent sessions")
@@ -785,6 +799,11 @@ Examples:
         "--detailed",
         action="store_true",
         help="Include tool use, MCP responses, and system messages in export"
+    )
+    parser.add_argument(
+        "--thinking",
+        action="store_true",
+        help="Include extended thinking blocks in export"
     )
 
     args = parser.parse_args()
@@ -880,12 +899,12 @@ Examples:
                     view_num = int(view_choice)
                     if 1 <= view_num <= len(file_paths_list):
                         selected_path = file_paths_list[view_num - 1]
-                        extractor.display_conversation(selected_path, detailed=args.detailed)
-                        
+                        extractor.display_conversation(selected_path, detailed=args.detailed, thinking=args.thinking)
+
                         # Offer to extract after viewing
                         extract_choice = input("\n📤 Extract this conversation? (y/N): ").strip().lower()
                         if extract_choice == 'y':
-                            conversation = extractor.extract_conversation(selected_path, detailed=args.detailed)
+                            conversation = extractor.extract_conversation(selected_path, detailed=args.detailed, thinking=args.thinking)
                             if conversation:
                                 session_id = selected_path.stem
                                 if args.format == "json":
@@ -933,8 +952,10 @@ Examples:
             print(f"\n📤 Extracting {len(indices)} session(s) as {args.format.upper()}...")
             if args.detailed:
                 print("📋 Including detailed tool use and system messages")
+            if args.thinking:
+                print("💭 Including extended thinking blocks")
             success, total = extractor.extract_multiple(
-                sessions, indices, format=args.format, detailed=args.detailed
+                sessions, indices, format=args.format, detailed=args.detailed, thinking=args.thinking
             )
             print(f"\n✅ Successfully extracted {success}/{total} sessions")
 
@@ -944,10 +965,12 @@ Examples:
         print(f"\n📤 Extracting {limit} most recent sessions as {args.format.upper()}...")
         if args.detailed:
             print("📋 Including detailed tool use and system messages")
+        if args.thinking:
+            print("💭 Including extended thinking blocks")
 
         indices = list(range(limit))
         success, total = extractor.extract_multiple(
-            sessions, indices, format=args.format, detailed=args.detailed
+            sessions, indices, format=args.format, detailed=args.detailed, thinking=args.thinking
         )
         print(f"\n✅ Successfully extracted {success}/{total} sessions")
 
@@ -956,10 +979,12 @@ Examples:
         print(f"\n📤 Extracting all {len(sessions)} sessions as {args.format.upper()}...")
         if args.detailed:
             print("📋 Including detailed tool use and system messages")
+        if args.thinking:
+            print("💭 Including extended thinking blocks")
 
         indices = list(range(len(sessions)))
         success, total = extractor.extract_multiple(
-            sessions, indices, format=args.format, detailed=args.detailed
+            sessions, indices, format=args.format, detailed=args.detailed, thinking=args.thinking
         )
         print(f"\n✅ Successfully extracted {success}/{total} sessions")
 

--- a/src/extract_claude_logs.py
+++ b/src/extract_claude_logs.py
@@ -11,26 +11,30 @@ import argparse
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    from .source_config import get_source_config, normalize_source
+except ImportError:
+    from source_config import get_source_config, normalize_source
 
 
 class ClaudeConversationExtractor:
     """Extract and convert Claude Code conversations from JSONL to markdown."""
 
-    def __init__(self, output_dir: Optional[Path] = None):
-        """Initialize the extractor with Claude's directory and output location."""
-        self.claude_dir = Path.home() / ".claude" / "projects"
+    def __init__(self, output_dir: Optional[Path] = None, source: str = "claude"):
+        """Initialize the extractor with source directory and output location."""
+        self.source = normalize_source(source)
+        self.source_config = get_source_config(self.source)
+        self.claude_dir = self.source_config["session_dir"]
+        self.session_dir = self.claude_dir
 
         if output_dir:
             self.output_dir = Path(output_dir)
             self.output_dir.mkdir(parents=True, exist_ok=True)
         else:
-            # Try multiple possible output directories
-            possible_dirs = [
-                Path.home() / "Desktop" / "Claude logs",
-                Path.home() / "Documents" / "Claude logs",
-                Path.home() / "Claude logs",
-                Path.cwd() / "claude-logs",
+            possible_dirs = self.source_config["default_output_dirs"] + [
+                self.source_config["default_output_fallback"]
             ]
 
             # Use the first directory we can create
@@ -46,8 +50,7 @@ class ClaudeConversationExtractor:
                 except Exception:
                     continue
             else:
-                # Fallback to current directory
-                self.output_dir = Path.cwd() / "claude-logs"
+                self.output_dir = self.source_config["default_output_fallback"]
                 self.output_dir.mkdir(exist_ok=True)
 
         print(f"📁 Saving logs to: {self.output_dir}")
@@ -55,14 +58,14 @@ class ClaudeConversationExtractor:
     def find_sessions(self, project_path: Optional[str] = None) -> List[Path]:
         """Find all JSONL session files, sorted by most recent first."""
         if project_path:
-            search_dir = self.claude_dir / project_path
+            search_dir = self.session_dir / project_path
         else:
-            search_dir = self.claude_dir
+            search_dir = self.session_dir
 
         sessions = []
         if search_dir.exists():
-            for jsonl_file in search_dir.rglob("*.jsonl"):
-                sessions.append(jsonl_file)
+            for session_file in search_dir.rglob(self.source_config["session_glob"]):
+                sessions.append(session_file)
         return sorted(sessions, key=lambda x: x.stat().st_mtime, reverse=True)
 
     def extract_conversation(self, jsonl_path: Path, detailed: bool = False, thinking: bool = False) -> List[Dict[str, str]]:
@@ -73,6 +76,17 @@ class ClaudeConversationExtractor:
             detailed: If True, include tool use, MCP responses, and system messages
             thinking: If True, include extended thinking blocks
         """
+        if self.source == "copilot":
+            return self._extract_copilot_conversation(
+                jsonl_path, detailed=detailed, thinking=thinking
+            )
+        return self._extract_claude_conversation(
+            jsonl_path, detailed=detailed, thinking=thinking
+        )
+
+    def _extract_claude_conversation(
+        self, jsonl_path: Path, detailed: bool = False, thinking: bool = False
+    ) -> List[Dict[str, str]]:
         conversation = []
 
         try:
@@ -81,87 +95,192 @@ class ClaudeConversationExtractor:
                     try:
                         entry = json.loads(line.strip())
 
-                        # Extract user messages
                         if entry.get("type") == "user" and "message" in entry:
                             msg = entry["message"]
                             if isinstance(msg, dict) and msg.get("role") == "user":
-                                content = msg.get("content", "")
-                                text = self._extract_text_content(content)
+                                text = self._extract_text_content(msg.get("content", ""))
+                                self._append_message(conversation, "user", text, entry.get("timestamp", ""))
 
-                                if text and text.strip():
-                                    conversation.append(
-                                        {
-                                            "role": "user",
-                                            "content": text,
-                                            "timestamp": entry.get("timestamp", ""),
-                                        }
-                                    )
-
-                        # Extract assistant messages
                         elif entry.get("type") == "assistant" and "message" in entry:
                             msg = entry["message"]
                             if isinstance(msg, dict) and msg.get("role") == "assistant":
-                                content = msg.get("content", [])
-                                text = self._extract_text_content(content, detailed=detailed, thinking=thinking)
+                                text = self._extract_text_content(
+                                    msg.get("content", []), detailed=detailed, thinking=thinking
+                                )
+                                self._append_message(
+                                    conversation, "assistant", text, entry.get("timestamp", "")
+                                )
 
-                                if text and text.strip():
-                                    conversation.append(
-                                        {
-                                            "role": "assistant",
-                                            "content": text,
-                                            "timestamp": entry.get("timestamp", ""),
-                                        }
-                                    )
-                        
-                        # Include tool use and system messages if detailed mode
                         elif detailed:
-                            # Extract tool use events
                             if entry.get("type") == "tool_use":
                                 tool_data = entry.get("tool", {})
-                                tool_name = tool_data.get("name", "unknown")
-                                tool_input = tool_data.get("input", {})
-                                conversation.append(
-                                    {
-                                        "role": "tool_use",
-                                        "content": f"🔧 Tool: {tool_name}\nInput: {json.dumps(tool_input, indent=2)}",
-                                        "timestamp": entry.get("timestamp", ""),
-                                    }
+                                self._append_message(
+                                    conversation,
+                                    "tool_use",
+                                    f"🔧 Tool: {tool_data.get('name', 'unknown')}\n"
+                                    f"Input: {json.dumps(tool_data.get('input', {}), indent=2)}",
+                                    entry.get("timestamp", ""),
                                 )
-                            
-                            # Extract tool results
                             elif entry.get("type") == "tool_result":
                                 result = entry.get("result", {})
                                 output = result.get("output", "") or result.get("error", "")
-                                conversation.append(
-                                    {
-                                        "role": "tool_result",
-                                        "content": f"📤 Result:\n{output}",
-                                        "timestamp": entry.get("timestamp", ""),
-                                    }
+                                self._append_message(
+                                    conversation,
+                                    "tool_result",
+                                    f"📤 Result:\n{output}",
+                                    entry.get("timestamp", ""),
                                 )
-                            
-                            # Extract system messages
                             elif entry.get("type") == "system" and "message" in entry:
-                                msg = entry.get("message", "")
-                                if msg:
-                                    conversation.append(
-                                        {
-                                            "role": "system",
-                                            "content": f"ℹ️ System: {msg}",
-                                            "timestamp": entry.get("timestamp", ""),
-                                        }
-                                    )
+                                self._append_message(
+                                    conversation,
+                                    "system",
+                                    f"ℹ️ System: {entry.get('message', '')}",
+                                    entry.get("timestamp", ""),
+                                )
 
                     except json.JSONDecodeError:
                         continue
                     except Exception:
-                        # Silently skip problematic entries
                         continue
 
         except Exception as e:
             print(f"❌ Error reading file {jsonl_path}: {e}")
 
         return conversation
+
+    def _extract_copilot_conversation(
+        self, jsonl_path: Path, detailed: bool = False, thinking: bool = False
+    ) -> List[Dict[str, str]]:
+        conversation = []
+
+        try:
+            with open(jsonl_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        entry = json.loads(line.strip())
+                        event_type = entry.get("type", "")
+                        data = entry.get("data", {})
+                        timestamp = entry.get("timestamp", "")
+
+                        if event_type == "user.message":
+                            text = self._extract_copilot_text_content(
+                                data.get("content", "") or data.get("transformedContent", "")
+                            )
+                            self._append_message(conversation, "user", text, timestamp)
+
+                        elif event_type == "assistant.message":
+                            text = self._extract_copilot_text_content(data.get("content", ""))
+                            if thinking and data.get("reasoningText"):
+                                text = f"{text}\n\n💭 Thinking:\n{data.get('reasoningText')}"
+                            self._append_message(conversation, "assistant", text, timestamp)
+
+                        elif detailed and event_type == "tool.execution_start":
+                            self._append_message(
+                                conversation,
+                                "tool_use",
+                                f"🔧 Tool: {data.get('toolName', 'unknown')}\n"
+                                f"Input: {self._stringify_value(data.get('arguments', {}))}",
+                                timestamp,
+                            )
+
+                        elif detailed and event_type == "tool.execution_complete":
+                            result_prefix = "📤 Result" if data.get("success") else "❌ Error"
+                            payload = data.get("result") if data.get("success") else data.get("error")
+                            self._append_message(
+                                conversation,
+                                "tool_result",
+                                f"{result_prefix}:\n{self._stringify_value(payload)}",
+                                timestamp,
+                            )
+
+                        elif detailed and event_type in {
+                            "session.info",
+                            "session.warning",
+                            "session.resume",
+                            "session.shutdown",
+                            "system.notification",
+                            "abort",
+                            "subagent.started",
+                        }:
+                            summary = data.get("message") or self._stringify_value(data)
+                            self._append_message(
+                                conversation,
+                                "system",
+                                f"ℹ️ {event_type}: {summary}",
+                                timestamp,
+                            )
+
+                    except json.JSONDecodeError:
+                        continue
+                    except Exception:
+                        continue
+
+        except Exception as e:
+            print(f"❌ Error reading file {jsonl_path}: {e}")
+
+        return conversation
+
+    def _append_message(
+        self, conversation: List[Dict[str, str]], role: str, content: str, timestamp: str
+    ) -> None:
+        if content and content.strip():
+            conversation.append(
+                {
+                    "role": role,
+                    "content": content,
+                    "timestamp": timestamp,
+                }
+            )
+
+    def _extract_copilot_text_content(self, content: Any) -> str:
+        """Extract text from Copilot event payloads."""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            return "\n".join(self._extract_copilot_text_content(item) for item in content if item)
+        if isinstance(content, dict):
+            if isinstance(content.get("text"), str):
+                return content["text"]
+            return self._stringify_value(content)
+        return str(content)
+
+    def _stringify_value(self, value: Any) -> str:
+        """Format structured values for readable export."""
+        if value is None:
+            return ""
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, indent=2, ensure_ascii=False)
+        return str(value)
+
+    def _get_session_id(self, session_path: Path) -> str:
+        """Return a stable session identifier for the active source."""
+        if self.source == "copilot" and session_path.name == "events.jsonl":
+            return session_path.parent.name
+        return session_path.stem
+
+    def _get_session_display_name(self, session_path: Path) -> str:
+        """Return the best available project/workspace label for a session."""
+        if self.source == "copilot":
+            try:
+                with open(session_path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        entry = json.loads(line.strip())
+                        if entry.get("type") == "session.start":
+                            context = entry.get("data", {}).get("context", {})
+                            cwd = context.get("cwd")
+                            if cwd:
+                                return Path(cwd).name or cwd
+                        if entry.get("type") == "user.message":
+                            break
+            except Exception:
+                pass
+            return session_path.parent.name
+
+        project = session_path.parent.name.replace("-", " ").strip()
+        if project.startswith("Users"):
+            parts = project.split()
+            project = "~/" + "/".join(parts[2:]) if len(parts) > 2 else "Home"
+        return project
 
     def _extract_text_content(self, content, detailed: bool = False, thinking: bool = False) -> str:
         """Extract text from various content formats Claude uses.
@@ -211,12 +330,12 @@ class ClaudeConversationExtractor:
                 return
             
             # Get session info
-            session_id = jsonl_path.stem
+            session_id = self._get_session_id(jsonl_path)
             
             # Clear screen and show header
             print("\033[2J\033[H", end="")  # Clear screen
             print("=" * 60)
-            print(f"📄 Viewing: {jsonl_path.parent.name}")
+            print(f"📄 Viewing: {self._get_session_display_name(jsonl_path)}")
             print(f"Session: {session_id[:8]}...")
             
             # Get timestamp from first message
@@ -246,7 +365,7 @@ class ClaudeConversationExtractor:
                     print(f"{'─' * 40}")
                 elif role == "assistant":
                     print(f"\n{'─' * 40}")
-                    print(f"🤖 CLAUDE:")
+                    print(f"🤖 {self.source_config['assistant_terminal_name']}:")
                     print(f"{'─' * 40}")
                 elif role == "tool_use":
                     print(f"\n🔧 TOOL USE:")
@@ -315,11 +434,11 @@ class ClaudeConversationExtractor:
             date_str = datetime.now().strftime("%Y-%m-%d")
             time_str = ""
 
-        filename = f"claude-conversation-{date_str}-{session_id[:8]}.md"
+        filename = f"{self.source_config['conversation_prefix']}-{date_str}-{session_id[:8]}.md"
         output_path = self.output_dir / filename
 
         with open(output_path, "w", encoding="utf-8") as f:
-            f.write("# Claude Conversation Log\n\n")
+            f.write(f"# {self.source_config['conversation_title']}\n\n")
             f.write(f"Session ID: {session_id}\n")
             f.write(f"Date: {date_str}")
             if time_str:
@@ -334,7 +453,7 @@ class ClaudeConversationExtractor:
                     f.write("## 👤 User\n\n")
                     f.write(f"{content}\n\n")
                 elif role == "assistant":
-                    f.write("## 🤖 Claude\n\n")
+                    f.write(f"{self.source_config['assistant_heading']}\n\n")
                     f.write(f"{content}\n\n")
                 elif role == "tool_use":
                     f.write("### 🔧 Tool Use\n\n")
@@ -373,11 +492,12 @@ class ClaudeConversationExtractor:
         else:
             date_str = datetime.now().strftime("%Y-%m-%d")
 
-        filename = f"claude-conversation-{date_str}-{session_id[:8]}.json"
+        filename = f"{self.source_config['conversation_prefix']}-{date_str}-{session_id[:8]}.json"
         output_path = self.output_dir / filename
 
         # Create JSON structure
         output = {
+            "source": self.source,
             "session_id": session_id,
             "date": date_str,
             "message_count": len(conversation),
@@ -410,7 +530,7 @@ class ClaudeConversationExtractor:
             date_str = datetime.now().strftime("%Y-%m-%d")
             time_str = ""
 
-        filename = f"claude-conversation-{date_str}-{session_id[:8]}.html"
+        filename = f"{self.source_config['conversation_prefix']}-{date_str}-{session_id[:8]}.html"
         output_path = self.output_dir / filename
 
         # HTML template with modern styling
@@ -419,7 +539,7 @@ class ClaudeConversationExtractor:
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Claude Conversation - {session_id[:8]}</title>
+    <title>{self.source_config['display_name']} Conversation - {session_id[:8]}</title>
     <style>
         body {{
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -496,7 +616,7 @@ class ClaudeConversationExtractor:
 </head>
 <body>
     <div class="header">
-        <h1>Claude Conversation Log</h1>
+        <h1>{self.source_config['conversation_title']}</h1>
         <div class="metadata">
             <p>Session ID: {session_id}</p>
             <p>Date: {date_str} {time_str}</p>
@@ -519,7 +639,7 @@ class ClaudeConversationExtractor:
                 
                 role_display = {
                     "user": "👤 User",
-                    "assistant": "🤖 Claude",
+                    "assistant": f"🤖 {self.source_config['assistant_name']}",
                     "tool_use": "🔧 Tool Use",
                     "tool_result": "📤 Tool Result",
                     "system": "ℹ️ System"
@@ -556,6 +676,9 @@ class ClaudeConversationExtractor:
 
     def get_conversation_preview(self, session_path: Path) -> Tuple[str, int]:
         """Get a preview of the conversation's first real user message and message count."""
+        if self.source == "copilot":
+            return self._get_copilot_conversation_preview(session_path)
+
         try:
             first_user_msg = ""
             msg_count = 0
@@ -636,27 +759,53 @@ class ClaudeConversationExtractor:
         except Exception as e:
             return f"Error: {str(e)[:30]}", 0
 
+    def _get_copilot_conversation_preview(self, session_path: Path) -> Tuple[str, int]:
+        """Get a preview of the first Copilot user message and message count."""
+        try:
+            first_user_msg = ""
+            msg_count = 0
+
+            with open(session_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    event_type = data.get("type")
+                    if event_type in {"user.message", "assistant.message"}:
+                        msg_count += 1
+
+                    if not first_user_msg and event_type == "user.message":
+                        text = self._extract_copilot_text_content(
+                            data.get("data", {}).get("content", "")
+                        ).strip()
+                        if text:
+                            first_user_msg = text[:100].replace("\n", " ")
+
+            return first_user_msg or "No preview available", msg_count
+        except Exception as e:
+            return f"Error: {str(e)[:30]}", 0
+
     def list_recent_sessions(self, limit: int = None) -> List[Path]:
         """List recent sessions with details."""
         sessions = self.find_sessions()
 
         if not sessions:
-            print("❌ No Claude sessions found in ~/.claude/projects/")
-            print("💡 Make sure you've used Claude Code and have conversations saved.")
+            print(f"❌ {self.source_config['no_sessions_message']}")
+            print(
+                f"💡 Make sure you've used {self.source_config['display_name']} and have conversations saved."
+            )
             return []
 
-        print(f"\n📚 Found {len(sessions)} Claude sessions:\n")
+        print(f"\n📚 Found {len(sessions)} {self.source_config['display_name']} sessions:\n")
         print("=" * 80)
 
         # Show all sessions if no limit specified
         sessions_to_show = sessions[:limit] if limit else sessions
         for i, session in enumerate(sessions_to_show, 1):
-            # Clean up project name (remove hyphens, make readable)
-            project = session.parent.name.replace('-', ' ').strip()
-            if project.startswith("Users"):
-                project = "~/" + "/".join(project.split()[2:]) if len(project.split()) > 2 else "Home"
-            
-            session_id = session.stem
+            project = self._get_session_display_name(session)
+            session_id = self._get_session_id(session)
             modified = datetime.fromtimestamp(session.stat().st_mtime)
 
             # Get file size
@@ -698,7 +847,9 @@ class ClaudeConversationExtractor:
                 session_path = sessions[idx]
                 conversation = self.extract_conversation(session_path, detailed=detailed, thinking=thinking)
                 if conversation:
-                    output_path = self.save_conversation(conversation, session_path.stem, format=format)
+                    output_path = self.save_conversation(
+                        conversation, self._get_session_id(session_path), format=format
+                    )
                     success += 1
                     msg_count = len(conversation)
                     print(
@@ -805,26 +956,38 @@ Examples:
         action="store_true",
         help="Include extended thinking blocks in export"
     )
+    parser.add_argument(
+        "--copilot",
+        action="store_true",
+        help="Extract and search GitHub Copilot CLI sessions from ~/.copilot/session-state",
+    )
 
     args = parser.parse_args()
+    source = "copilot" if args.copilot else "claude"
 
     # Handle interactive mode
     if args.interactive or (args.export and args.export.lower() == "logs"):
-        from interactive_ui import main as interactive_main
+        try:
+            from .interactive_ui import main as interactive_main
+        except ImportError:
+            from interactive_ui import main as interactive_main
 
-        interactive_main()
+        interactive_main(source=source)
         return
 
     # Initialize extractor with optional output directory
-    extractor = ClaudeConversationExtractor(args.output)
+    extractor = ClaudeConversationExtractor(args.output, source=source)
 
     # Handle search mode
     if args.search or args.search_regex:
         from datetime import datetime
 
-        from search_conversations import ConversationSearcher
+        try:
+            from .search_conversations import ConversationSearcher
+        except ImportError:
+            from search_conversations import ConversationSearcher
 
-        searcher = ConversationSearcher()
+        searcher = ConversationSearcher(source=source)
 
         # Determine search mode and query
         if args.search_regex:
@@ -906,7 +1069,7 @@ Examples:
                         if extract_choice == 'y':
                             conversation = extractor.extract_conversation(selected_path, detailed=args.detailed, thinking=args.thinking)
                             if conversation:
-                                session_id = selected_path.stem
+                                session_id = extractor._get_session_id(selected_path)
                                 if args.format == "json":
                                     output = extractor.save_as_json(conversation, session_id)
                                 elif args.format == "html":
@@ -934,6 +1097,8 @@ Examples:
             print("  claude-extract --extract <number>      # Extract specific session")
             print("  claude-extract --recent 5              # Extract 5 most recent")
             print("  claude-extract --all                   # Extract all sessions")
+            if args.copilot:
+                print("  claude-extract --copilot --extract <number>")
 
     elif args.extract:
         sessions = extractor.find_sessions()
@@ -1011,8 +1176,9 @@ def launch_interactive():
             from search_conversations import ConversationSearcher
         
         # Initialize components
-        extractor = ClaudeConversationExtractor()
-        searcher = ConversationSearcher()
+        source = "copilot" if "--copilot" in sys.argv[2:] else "claude"
+        extractor = ClaudeConversationExtractor(source=source)
+        searcher = ConversationSearcher(source=source)
         smart_searcher = create_smart_searcher(searcher)
         
         # Run search
@@ -1029,7 +1195,7 @@ def launch_interactive():
                 if extract_choice == 'y':
                     conversation = extractor.extract_conversation(selected_file)
                     if conversation:
-                        session_id = selected_file.stem
+                        session_id = extractor._get_session_id(selected_file)
                         output = extractor.save_as_markdown(conversation, session_id)
                         print(f"✅ Saved: {output.name}")
             except (EOFError, KeyboardInterrupt):

--- a/src/interactive_ui.py
+++ b/src/interactive_ui.py
@@ -14,20 +14,24 @@ try:
     from .extract_claude_logs import ClaudeConversationExtractor
     from .realtime_search import RealTimeSearch, create_smart_searcher
     from .search_conversations import ConversationSearcher
+    from .source_config import get_source_config, normalize_source
 except ImportError:
     # Fallback for direct execution or when not installed as package
     from extract_claude_logs import ClaudeConversationExtractor
     from realtime_search import RealTimeSearch, create_smart_searcher
     from search_conversations import ConversationSearcher
+    from source_config import get_source_config, normalize_source
 
 
 class InteractiveUI:
     """Interactive terminal UI for easier conversation extraction"""
 
-    def __init__(self, output_dir: Optional[str] = None):
+    def __init__(self, output_dir: Optional[str] = None, source: str = "claude"):
         self.output_dir = output_dir
-        self.extractor = ClaudeConversationExtractor(output_dir)
-        self.searcher = ConversationSearcher()
+        self.source = normalize_source(source)
+        self.source_config = get_source_config(self.source)
+        self.extractor = ClaudeConversationExtractor(output_dir, source=self.source)
+        self.searcher = ConversationSearcher(source=self.source)
         self.sessions: List[Path] = []
         self.terminal_width = shutil.get_terminal_size().columns
 
@@ -75,10 +79,10 @@ class InteractiveUI:
         # Suggest common locations
         home = Path.home()
         suggestions = [
-            home / "Desktop" / "Claude Conversations",
-            home / "Documents" / "Claude Conversations",
-            home / "Downloads" / "Claude Conversations",
-            Path.cwd() / "Claude Conversations",
+            home / "Desktop" / self.source_config["interactive_output_name"],
+            home / "Documents" / self.source_config["interactive_output_name"],
+            home / "Downloads" / self.source_config["interactive_output_name"],
+            Path.cwd() / self.source_config["interactive_output_name"],
         ]
 
         print("Suggested locations:")
@@ -108,12 +112,12 @@ class InteractiveUI:
         self.print_banner()
 
         # Get all sessions
-        print("\n🔍 Finding your Claude conversations...")
+        print(f"\n🔍 Finding your {self.source_config['display_name']} conversations...")
         self.sessions = self.extractor.find_sessions()
 
         if not self.sessions:
-            print("\n❌ No Claude conversations found!")
-            print("Make sure you've used Claude Code at least once.")
+            print(f"\n❌ No {self.source_config['display_name']} conversations found!")
+            print(f"Make sure you've used {self.source_config['display_name']} at least once.")
             input("\nPress Enter to exit...")
             return []
 
@@ -121,7 +125,7 @@ class InteractiveUI:
 
         # Display sessions
         for i, session_path in enumerate(self.sessions[:20], 1):  # Show max 20
-            project = session_path.parent.name
+            project = self.extractor._get_session_display_name(session_path)
             modified = datetime.fromtimestamp(session_path.stat().st_mtime)
             size_kb = session_path.stat().st_size / 1024
 
@@ -274,9 +278,9 @@ class InteractiveUI:
             input("\nPress Enter to exit...")
 
 
-def main():
+def main(source: str = "claude"):
     """Entry point for interactive UI"""
-    ui = InteractiveUI()
+    ui = InteractiveUI(source=source)
     ui.run()
 
 

--- a/src/search_cli.py
+++ b/src/search_cli.py
@@ -4,7 +4,7 @@ Simple CLI search for Claude conversations without terminal control.
 This is used when running `claude-search` from the command line.
 """
 
-import sys
+import argparse
 
 # Handle both package and direct execution imports
 try:
@@ -20,12 +20,19 @@ except ImportError:
 
 def main():
     """Main entry point for CLI search."""
-    # Get search term from stdin or arguments
-    if len(sys.argv) > 1:
-        # Search term provided as argument
-        search_term = " ".join(sys.argv[1:])
+    parser = argparse.ArgumentParser(description="Search extracted conversations")
+    parser.add_argument("search_term", nargs="*", help="Search terms")
+    parser.add_argument(
+        "--copilot",
+        action="store_true",
+        help="Search GitHub Copilot CLI sessions from ~/.copilot/session-state",
+    )
+    args = parser.parse_args()
+    source = "copilot" if args.copilot else "claude"
+
+    if args.search_term:
+        search_term = " ".join(args.search_term)
     else:
-        # Prompt for search term
         try:
             search_term = input("🔍 Enter search term: ").strip()
         except (EOFError, KeyboardInterrupt):
@@ -40,7 +47,7 @@ def main():
     print("=" * 60)
     
     # Initialize searcher
-    searcher = ConversationSearcher()
+    searcher = ConversationSearcher(source=source)
     smart_searcher = create_smart_searcher(searcher)
     
     # Perform search
@@ -60,16 +67,16 @@ def main():
         # Display results
         sessions = []
         session_paths = []
-        extractor = ClaudeConversationExtractor()
+        extractor = ClaudeConversationExtractor(source=source)
         all_sessions = extractor.find_sessions()
         
         for i, (fname, file_results) in enumerate(by_file.items(), 1):
-            session_id = fname.replace('.jsonl', '')
+            session_id = extractor._get_session_id(file_results[0].file_path)
             sessions.append((fname, session_id))
             
             # Find the actual file path
             for session_path in all_sessions:
-                if session_path.name == fname:
+                if session_path == file_results[0].file_path:
                     session_paths.append(session_path)
                     break
             

--- a/src/search_conversations.py
+++ b/src/search_conversations.py
@@ -19,6 +19,11 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+try:
+    from .source_config import get_source_config, normalize_source
+except ImportError:
+    from source_config import get_source_config, normalize_source
+
 # Optional NLP imports for semantic search
 try:
     import spacy
@@ -62,14 +67,16 @@ class ConversationSearcher:
     Provides multiple search modes and intelligent ranking.
     """
 
-    def __init__(self, cache_dir: Optional[Path] = None):
+    def __init__(self, cache_dir: Optional[Path] = None, source: str = "claude"):
         """
         Initialize the searcher.
 
         Args:
             cache_dir: Optional directory for caching processed conversations
         """
-        self.cache_dir = cache_dir or Path.home() / ".claude" / ".search_cache"
+        self.source = normalize_source(source)
+        self.source_config = get_source_config(self.source)
+        self.cache_dir = cache_dir or self.source_config["cache_dir"]
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
         # Initialize NLP if available
@@ -154,7 +161,7 @@ class ConversationSearcher:
         """
         # Default search directory
         if search_dir is None:
-            search_dir = Path.home() / ".claude" / "projects"
+            search_dir = self.source_config["session_dir"]
 
         # Validate search directory
         if not search_dir.exists():
@@ -165,7 +172,7 @@ class ConversationSearcher:
             return []
 
         # Find all JSONL files
-        jsonl_files = list(search_dir.rglob("*.jsonl"))
+        jsonl_files = list(search_dir.rglob(self.source_config["session_glob"]))
         if not jsonl_files:
             return []
 
@@ -234,7 +241,7 @@ class ConversationSearcher:
         Uses exact matching, fuzzy matching, and semantic similarity.
         """
         results = []
-        conversation_id = jsonl_file.stem
+        conversation_id = self._get_conversation_id(jsonl_file)
 
         # Process query
         if not case_sensitive:
@@ -253,10 +260,8 @@ class ConversationSearcher:
                         entry = json.loads(line.strip())
 
                         # Extract message based on entry type
-                        if entry.get("type") in ["user", "assistant"]:
-                            speaker = (
-                                "human" if entry["type"] == "user" else "assistant"
-                            )
+                        if self._is_message_entry(entry):
+                            speaker = self._get_speaker(entry)
 
                             # Apply speaker filter
                             if speaker_filter and speaker != speaker_filter:
@@ -318,7 +323,7 @@ class ConversationSearcher:
     ) -> List[SearchResult]:
         """Exact string matching search."""
         results = []
-        conversation_id = jsonl_file.stem
+        conversation_id = self._get_conversation_id(jsonl_file)
 
         search_query = query if case_sensitive else query.lower()
 
@@ -330,10 +335,8 @@ class ConversationSearcher:
                     try:
                         entry = json.loads(line.strip())
 
-                        if entry.get("type") in ["user", "assistant"]:
-                            speaker = (
-                                "human" if entry["type"] == "user" else "assistant"
-                            )
+                        if self._is_message_entry(entry):
+                            speaker = self._get_speaker(entry)
 
                             if speaker_filter and speaker != speaker_filter:
                                 continue
@@ -395,7 +398,7 @@ class ConversationSearcher:
     ) -> List[SearchResult]:
         """Regex pattern matching search."""
         results = []
-        conversation_id = jsonl_file.stem
+        conversation_id = self._get_conversation_id(jsonl_file)
 
         # Compile regex pattern
         try:
@@ -413,10 +416,8 @@ class ConversationSearcher:
                     try:
                         entry = json.loads(line.strip())
 
-                        if entry.get("type") in ["user", "assistant"]:
-                            speaker = (
-                                "human" if entry["type"] == "user" else "assistant"
-                            )
+                        if self._is_message_entry(entry):
+                            speaker = self._get_speaker(entry)
 
                             if speaker_filter and speaker != speaker_filter:
                                 continue
@@ -480,7 +481,7 @@ class ConversationSearcher:
             return []
 
         results = []
-        conversation_id = jsonl_file.stem
+        conversation_id = self._get_conversation_id(jsonl_file)
 
         # Process query with spaCy
         query_doc = self.nlp(query.lower())
@@ -496,10 +497,8 @@ class ConversationSearcher:
                     try:
                         entry = json.loads(line.strip())
 
-                        if entry.get("type") in ["user", "assistant"]:
-                            speaker = (
-                                "human" if entry["type"] == "user" else "assistant"
-                            )
+                        if self._is_message_entry(entry):
+                            speaker = self._get_speaker(entry)
 
                             if speaker_filter and speaker != speaker_filter:
                                 continue
@@ -552,6 +551,20 @@ class ConversationSearcher:
 
     def _extract_content(self, entry: Dict) -> str:
         """Extract text content from a JSONL entry."""
+        if entry.get("type") == "user.message":
+            data = entry.get("data", {})
+            return self._extract_copilot_content(
+                data.get("content", "") or data.get("transformedContent", "")
+            )
+
+        if entry.get("type") == "assistant.message":
+            data = entry.get("data", {})
+            content = self._extract_copilot_content(data.get("content", ""))
+            reasoning = self._extract_copilot_content(data.get("reasoningText", ""))
+            if content and reasoning:
+                return f"{content}\n{reasoning}"
+            return content or reasoning
+
         # Handle test format (type: user/assistant, content: string)
         if entry.get("type") in ["user", "assistant"] and "content" in entry:
             content = entry["content"]
@@ -578,6 +591,41 @@ class ConversationSearcher:
                     return content
 
         return ""
+
+    def _extract_copilot_content(self, content) -> str:
+        """Extract text from Copilot event content payloads."""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [self._extract_copilot_content(item) for item in content]
+            return " ".join(part for part in parts if part)
+        if isinstance(content, dict):
+            text = content.get("text")
+            if isinstance(text, str):
+                return text
+            return json.dumps(content, ensure_ascii=False)
+        return ""
+
+    def _is_message_entry(self, entry: Dict) -> bool:
+        """Return True for searchable user/assistant messages."""
+        return entry.get("type") in {
+            "user",
+            "assistant",
+            "user.message",
+            "assistant.message",
+        }
+
+    def _get_speaker(self, entry: Dict) -> str:
+        """Normalize entry type to human/assistant speaker labels."""
+        if entry.get("type") in {"user", "user.message"}:
+            return "human"
+        return "assistant"
+
+    def _get_conversation_id(self, jsonl_file: Path) -> str:
+        """Return a stable conversation identifier for a session file."""
+        if jsonl_file.name == "events.jsonl":
+            return jsonl_file.parent.name
+        return jsonl_file.stem
 
     def _calculate_relevance(
         self, content: str, query: str, query_tokens: Set[str], case_sensitive: bool
@@ -701,9 +749,9 @@ class ConversationSearcher:
     ) -> List[Path]:
         """Find all conversation files within a date range."""
         if search_dir is None:
-            search_dir = Path.home() / ".claude" / "projects"
+            search_dir = self.source_config["session_dir"]
 
-        jsonl_files = list(search_dir.rglob("*.jsonl"))
+        jsonl_files = list(search_dir.rglob(self.source_config["session_glob"]))
         return self._filter_files_by_date(jsonl_files, date_from, date_to)
 
     def get_conversation_topics(

--- a/src/source_config.py
+++ b/src/source_config.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+
+SUPPORTED_SOURCES = ("claude", "copilot")
+
+
+def normalize_source(source: str) -> str:
+    """Normalize a conversation source identifier."""
+    if source in SUPPORTED_SOURCES:
+        return source
+    return "claude"
+
+
+def get_source_config(source: str):
+    """Return source-specific paths and labels."""
+    source = normalize_source(source)
+    home = Path.home()
+
+    base = {
+        "claude": {
+            "source": "claude",
+            "display_name": "Claude",
+            "assistant_name": "Claude",
+            "session_dir": home / ".claude" / "projects",
+            "cache_dir": home / ".claude" / ".search_cache",
+            "default_output_dirs": [
+                home / "Desktop" / "Claude logs",
+                home / "Documents" / "Claude logs",
+                home / "Claude logs",
+            ],
+            "default_output_fallback": Path.cwd() / "claude-logs",
+            "interactive_output_name": "Claude Conversations",
+            "conversation_prefix": "claude-conversation",
+            "conversation_title": "Claude Conversation Log",
+            "assistant_heading": "## 🤖 Claude",
+            "assistant_terminal_name": "CLAUDE",
+            "no_sessions_message": "No Claude sessions found in ~/.claude/projects/",
+            "session_glob": "*.jsonl",
+        },
+        "copilot": {
+            "source": "copilot",
+            "display_name": "Copilot",
+            "assistant_name": "Copilot",
+            "session_dir": home / ".copilot" / "session-state",
+            "cache_dir": home / ".copilot" / ".search_cache",
+            "default_output_dirs": [
+                home / "Desktop" / "Copilot logs",
+                home / "Documents" / "Copilot logs",
+                home / "Copilot logs",
+            ],
+            "default_output_fallback": Path.cwd() / "copilot-logs",
+            "interactive_output_name": "Copilot Conversations",
+            "conversation_prefix": "copilot-conversation",
+            "conversation_title": "Copilot Conversation Log",
+            "assistant_heading": "## 🤖 Copilot",
+            "assistant_terminal_name": "COPILOT",
+            "no_sessions_message": "No Copilot sessions found in ~/.copilot/session-state/",
+            "session_glob": "events.jsonl",
+        },
+    }
+
+    return base[source]

--- a/tests/test_copilot_support.py
+++ b/tests/test_copilot_support.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Focused tests for GitHub Copilot CLI session support.
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Add parent directory to path before local imports
+sys.path.append(str(Path(__file__).parent.parent))
+
+from extract_claude_logs import ClaudeConversationExtractor, main  # noqa: E402
+from search_conversations import ConversationSearcher  # noqa: E402
+
+
+class TestCopilotSupport(unittest.TestCase):
+    """Test extraction and search for Copilot CLI sessions."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.home = Path(self.temp_dir)
+        self.output_dir = self.home / "exports"
+        self.session_dir = (
+            self.home
+            / ".copilot"
+            / "session-state"
+            / "11111111-2222-3333-4444-555555555555"
+        )
+        self.session_dir.mkdir(parents=True)
+        self.events_file = self.session_dir / "events.jsonl"
+
+        events = [
+            {
+                "type": "session.start",
+                "timestamp": "2026-06-21T10:00:00Z",
+                "data": {
+                    "sessionId": self.session_dir.name,
+                    "context": {"cwd": "/tmp/demo-repo"},
+                },
+            },
+            {
+                "type": "user.message",
+                "timestamp": "2026-06-21T10:01:00Z",
+                "data": {"content": "Search for this Copilot session"},
+            },
+            {
+                "type": "assistant.message",
+                "timestamp": "2026-06-21T10:01:02Z",
+                "data": {
+                    "content": "I found the requested session.",
+                    "reasoningText": "Summarized the session content.",
+                },
+            },
+            {
+                "type": "tool.execution_start",
+                "timestamp": "2026-06-21T10:01:03Z",
+                "data": {"toolName": "view", "arguments": {"path": "README.md"}},
+            },
+            {
+                "type": "tool.execution_complete",
+                "timestamp": "2026-06-21T10:01:04Z",
+                "data": {"success": True, "result": {"output": "file content"}},
+            },
+        ]
+
+        self.events_file.write_text(
+            "\n".join(json.dumps(event) for event in events), encoding="utf-8"
+        )
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_copilot_default_output_directory(self):
+        """Copilot mode should default to a Copilot logs destination."""
+        with patch("pathlib.Path.home", return_value=self.home):
+            extractor = ClaudeConversationExtractor(source="copilot")
+
+        self.assertEqual(extractor.output_dir, self.home / "Desktop" / "Copilot logs")
+
+    def test_find_copilot_sessions(self):
+        """Copilot mode should find events.jsonl session files."""
+        with patch("pathlib.Path.home", return_value=self.home):
+            extractor = ClaudeConversationExtractor(self.output_dir, source="copilot")
+            sessions = extractor.find_sessions()
+
+        self.assertEqual(sessions, [self.events_file])
+
+    def test_extract_copilot_conversation(self):
+        """Copilot mode should extract user and assistant messages."""
+        with patch("pathlib.Path.home", return_value=self.home):
+            extractor = ClaudeConversationExtractor(self.output_dir, source="copilot")
+            conversation = extractor.extract_conversation(
+                self.events_file, detailed=True, thinking=True
+            )
+
+        self.assertEqual(len(conversation), 4)
+        self.assertEqual(conversation[0]["role"], "user")
+        self.assertEqual(conversation[0]["content"], "Search for this Copilot session")
+        self.assertEqual(conversation[1]["role"], "assistant")
+        self.assertIn("I found the requested session.", conversation[1]["content"])
+        self.assertIn("💭 Thinking:", conversation[1]["content"])
+        self.assertEqual(conversation[2]["role"], "tool_use")
+        self.assertEqual(conversation[3]["role"], "tool_result")
+
+    def test_save_copilot_markdown_uses_copilot_branding(self):
+        """Copilot exports should use Copilot titles and filename prefixes."""
+        with patch("pathlib.Path.home", return_value=self.home):
+            extractor = ClaudeConversationExtractor(self.output_dir, source="copilot")
+            conversation = extractor.extract_conversation(self.events_file)
+            output = extractor.save_as_markdown(conversation, self.session_dir.name)
+
+        self.assertTrue(output.name.startswith("copilot-conversation-"))
+        content = output.read_text(encoding="utf-8")
+        self.assertIn("# Copilot Conversation Log", content)
+        self.assertIn("## 🤖 Copilot", content)
+
+    def test_search_copilot_sessions(self):
+        """ConversationSearcher should search Copilot event streams."""
+        with patch("pathlib.Path.home", return_value=self.home):
+            searcher = ConversationSearcher(source="copilot")
+            results = searcher.search("requested session", mode="exact")
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].conversation_id, self.session_dir.name)
+        self.assertEqual(results[0].speaker, "assistant")
+
+    def test_main_copilot_flag_uses_copilot_source(self):
+        """The --copilot flag should instantiate the extractor in Copilot mode."""
+        with patch("sys.argv", ["extract_claude_logs.py", "--copilot", "--list"]):
+            with patch("extract_claude_logs.ClaudeConversationExtractor") as mock_class:
+                mock_class.return_value.list_recent_sessions.return_value = []
+                main()
+
+        mock_class.assert_called_once_with(None, source="copilot")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
As the title says, this adds a flag to include thinking blocks in the generated markdown files.

Note that in the latest Claude Code, you need to have `"showThinkingSummaries": true` in `.claude/settings.json` to preserve thinking blocks, otherwise they are stripped from the JSONL files entirely and extraction won't work. This appears to be a [bug in Claude Code](https://github.com/anthropics/claude-code/issues/32810).