### PR TITLE
fix: cache parsed conversations

### DIFF
--- a/src/extract_claude_logs.py
+++ b/src/extract_claude_logs.py
@@ -20,6 +20,9 @@ class ClaudeConversationExtractor:
     def __init__(self, output_dir: Optional[Path] = None):
         """Initialize the extractor with Claude's directory and output location."""
         self.claude_dir = Path.home() / ".claude" / "projects"
+        self._conversation_cache: Dict[
+            Tuple[Path, bool, int, int], List[Dict[str, str]]
+        ] = {}
 
         if output_dir:
             self.output_dir = Path(output_dir)
@@ -65,13 +68,28 @@ class ClaudeConversationExtractor:
                 sessions.append(jsonl_file)
         return sorted(sessions, key=lambda x: x.stat().st_mtime, reverse=True)
 
-    def extract_conversation(self, jsonl_path: Path, detailed: bool = False) -> List[Dict[str, str]]:
+    def extract_conversation(
+        self, jsonl_path: Path, detailed: bool = False
+    ) -> List[Dict[str, str]]:
         """Extract conversation messages from a JSONL file.
-        
+
         Args:
             jsonl_path: Path to the JSONL file
             detailed: If True, include tool use, MCP responses, and system messages
         """
+        jsonl_path = Path(jsonl_path)
+        cache_key = None
+
+        try:
+            file_stat = jsonl_path.stat()
+            cache_path = jsonl_path.resolve()
+            cache_key = (cache_path, detailed, file_stat.st_mtime_ns, file_stat.st_size)
+            cached_conversation = self._conversation_cache.get(cache_key)
+            if cached_conversation is not None:
+                return [message.copy() for message in cached_conversation]
+        except Exception:
+            pass
+
         conversation = []
 
         try:
@@ -122,7 +140,10 @@ class ClaudeConversationExtractor:
                                 conversation.append(
                                     {
                                         "role": "tool_use",
-                                        "content": f"🔧 Tool: {tool_name}\nInput: {json.dumps(tool_input, indent=2)}",
+                                        "content": (
+                                            f"🔧 Tool: {tool_name}\n"
+                                            f"Input: {json.dumps(tool_input, indent=2)}"
+                                        ),
                                         "timestamp": entry.get("timestamp", ""),
                                     }
                                 )
@@ -159,6 +180,23 @@ class ClaudeConversationExtractor:
 
         except Exception as e:
             print(f"❌ Error reading file {jsonl_path}: {e}")
+
+        if cache_key is not None:
+            cache_path, cache_detailed, _, _ = cache_key
+            stale_keys = [
+                key
+                for key in self._conversation_cache
+                if (
+                    key[0] == cache_path
+                    and key[1] == cache_detailed
+                    and key != cache_key
+                )
+            ]
+            for stale_key in stale_keys:
+                del self._conversation_cache[stale_key]
+            self._conversation_cache[cache_key] = [
+                message.copy() for message in conversation
+            ]
 
         return conversation
 

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,5 +1,6 @@
 """Tests for Claude Conversation Extractor"""
 
+import builtins
 import json
 import sys
 import tempfile
@@ -122,6 +123,53 @@ class TestClaudeConversationExtractor(unittest.TestCase):
         self.assertEqual(conversation[0]["content"], "Test message")
         self.assertEqual(conversation[1]["role"], "assistant")
         self.assertEqual(conversation[1]["content"], "Test response")
+
+    def test_extract_conversation_reuses_cached_parse_for_unchanged_file(self):
+        """Test extracting an unchanged conversation does not reopen the JSONL."""
+        jsonl_file = Path(self.temp_dir) / "test.jsonl"
+        jsonl_file.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {"role": "user", "content": "Test message"},
+                    "timestamp": "2025-05-25T10:00:00Z",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        original_open = builtins.open
+        opens = []
+
+        def counting_open(path, *args, **kwargs):
+            if Path(path) == jsonl_file:
+                opens.append(path)
+            return original_open(path, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=counting_open):
+            first = self.extractor.extract_conversation(jsonl_file)
+            second = self.extractor.extract_conversation(jsonl_file)
+
+            jsonl_file.write_text(
+                json.dumps(
+                    {
+                        "type": "user",
+                        "message": {
+                            "role": "user",
+                            "content": "Updated test message",
+                        },
+                        "timestamp": "2025-05-25T10:00:00Z",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            third = self.extractor.extract_conversation(jsonl_file)
+
+        self.assertEqual(first, second)
+        self.assertEqual(third[0]["content"], "Updated test message")
+        self.assertEqual(len(opens), 2)
 
     def test_extract_conversation_invalid_file(self):
         """Test extracting conversation from non-existent file"""


### PR DESCRIPTION
## What This PR Does
Caches parsed JSONL conversations per extractor instance and returns copies of cached messages to callers.

## Why This Change
Fixes #30.

Reusing parsed messages avoids reopening and reparsing the same unchanged session file on repeated views. Cache entries are invalidated when the file size or modification timestamp changes.

## Testing
- [x] Added/updated tests
- [x] `uv run --with pytest pytest tests/test_extractor.py::TestClaudeConversationExtractor::test_extract_conversation_reuses_cached_parse_for_unchanged_file -q` -> `1 passed in 0.05s`
- [x] `git diff --check origin/main...HEAD` -> passed
- [x] Branch naming and commit trailers checked

## Screenshots (if UI changes)
n/a
